### PR TITLE
Make the category map in detection dataset more flexible

### DIFF
--- a/rtdetrv2_pytorch/rtdetrv2/data/dataset/_dataset.py
+++ b/rtdetrv2_pytorch/rtdetrv2/data/dataset/_dataset.py
@@ -1,6 +1,5 @@
 """Copyright(c) 2023 lyuwenyu. All Rights Reserved."""
 
-import torch
 import torch.utils.data as data
 
 
@@ -22,3 +21,27 @@ class DetDataset(data.Dataset):
     @property
     def epoch(self):
         return self._epoch if hasattr(self, "_epoch") else -1
+
+    @property
+    def categories(
+        self,
+    ):
+        return None
+
+    @property
+    def category2name(
+        self,
+    ):
+        return None
+
+    @property
+    def category2label(
+        self,
+    ):
+        return None
+
+    @property
+    def label2category(
+        self,
+    ):
+        return None


### PR DESCRIPTION
## Modifications
1. Move properties of the category map to `DetDataset` for better consistent interface in detection task
2. For backward compatibility, keep `remap_mscoco_category` config and switch the source of category map based on it.
3. Change to use properties of `DetDataset` in `evaluate()` instead of importing `mscoco_label2category` directly

## Improvements
### Custom dataset
1. Convert labels to categories automatically without modifying the mscoco's category map.

### `RTDETRPostProcessor`
1. Allow using different category map for label conversion
